### PR TITLE
Updated the dotnet target framework to 8.

### DIFF
--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
     <OutputType>WinExe</OutputType>
 
     <RootNamespace>SG.Checkouts_Overview.Test</RootNamespace>
+    <CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/app/Checkouts-Overview.csproj
+++ b/app/Checkouts-Overview.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
     <RootNamespace>SG.Checkouts_Overview</RootNamespace>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>..\doc\icon\332 clone.ico</ApplicationIcon>
@@ -10,8 +10,9 @@
     <Product>Checkouts Overview</Product>
     <Description>Visual overview of local repository checkouts</Description>
     <Copyright>Copyright 2021-2024, by SGrottel</Copyright>
-    <Version>1.3.5</Version>
+    <Version>1.3.6</Version>
     <Nullable>enable</Nullable>
+    <CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/app/Properties/PublishProfiles/FolderProfile.pubxml
@@ -9,7 +9,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Also, disabled WinRT AoT optimization, as it triggers a compile error within the Windows sdk. Patch version bump to 1.3.6 due to the new framework requirement